### PR TITLE
Groundwork for #32.

### DIFF
--- a/constants.asm
+++ b/constants.asm
@@ -31,6 +31,7 @@
 %define THREAD_BUFFER_SIZE 8192 ; 8KB recv buffer
 %define URL_LENGTH_LIMIT 2000
 %define DIRECTORY_LENGTH_LIMIT 100
+%define DIRECTORY_LIST_BUFFER 1024
 
 ;Request Types
 %define REQ_UNK    0

--- a/data.asm
+++ b/data.asm
@@ -26,6 +26,11 @@
     timeval: ;struct
         tv_sec  dq 0
         tv_usec dq 0
+    dirent: ;struct
+        d_ino dq 0
+        d_off dq 0
+        d_reclen dw 0
+        d_name db DIRECTORY_LENGTH_LIMIT
     sigaction: ;struct
         sa_handler  dq 0
         sa_flags    dq SA_RESTORER ; also dq, because padding

--- a/syscall.asm
+++ b/syscall.asm
@@ -141,10 +141,17 @@ sys_create_tcp_socket:
     stackpop
     ret
 
-sys_open_directory:;rdi = path, rax = ret ( fd )
+sys_open_directory:;rdi = path, rax = ret ( fd ), rdx = flags
     stackpush
-    mov rsi, OPEN_DIRECTORY | OPEN_RDONLY ;flags 
+    mov rsi, rdx ;flags
     mov rax, SYS_OPEN
+    syscall
+    stackpop
+    ret
+
+sys_get_dir_listing:;rdi = fd, rsi = buffer, rdx = buffer_size
+    stackpush
+    mov rax, SYS_GETDENTS
     syscall
     stackpop
     ret


### PR DESCRIPTION
Added check for directory listing in request life cycle. Added syscall for getdents and created buffer to store entries in. First entry is saved in memory which can be used to retrieve the remaining entries:

linux_dirent:
unsigned long  d_ino;     /* Inode number */
unsigned long  d_off;     /* Offset to next linux_dirent */
unsigned short d_reclen;  /* Length of this linux_dirent */
char                  d_name[];  /* Filename (null-terminated) */