### PR TITLE
adding minimalist dockerifile for asmttpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stable-slim AS build
+WORKDIR /opt
+RUN apt update -y && apt install make yasm binutils -y
+COPY . .
+RUN make release
+
+FROM scratch
+COPY --from=build /opt/asmttpd /
+COPY --from=build /opt/web_root /web_root
+ENTRYPOINT ["/asmttpd"]
+CMD ["/web_root", "80"]


### PR DESCRIPTION
can run 14kb asmttpd docker image easily 
```bash
docker build -t asmttpd -f Dockerfile .

docker run -it  -p 80:80 asmttpd
```