### PR TITLE
Byte wise comparison

### DIFF
--- a/data.asm
+++ b/data.asm
@@ -171,3 +171,13 @@
     http_dir_entry_open_a_tag_pre db '<p><a href="',0x00
     http_dir_entry_open_a_tag_post db '">',0x00
     http_dir_entry_close_a_tag db '</a></p>',0x00
+
+    ; Request type
+    req_types db 'GET', 0     
+    req_get_length equ $ - req_types - 1 
+
+    req_head db 'HEAD', 0     
+    req_head_length equ $ - req_head - 1 
+
+    req_type_ptrs dq req_types, req_head ; array of request types
+    req_type_lengths dq req_get_length, req_head_length 

--- a/data.asm
+++ b/data.asm
@@ -174,10 +174,10 @@
 
     ; Request type
     req_get db 'GET', 0     
-    req_get_length equ $ - req_get - 1 
+    req_get_offset equ $ - req_get
 
     req_head db 'HEAD', 0     
-    req_head_length equ $ - req_head - 1 
+    req_head_offset equ $ - req_head
 
     req_type_ptrs dq req_get, req_head ; array of request types
-    req_type_lengths dq req_get_length, req_head_length 
+    req_type_count equ ($ - req_type_ptrs) / 8

--- a/data.asm
+++ b/data.asm
@@ -173,11 +173,11 @@
     http_dir_entry_close_a_tag db '</a></p>',0x00
 
     ; Request type
-    req_types db 'GET', 0     
-    req_get_length equ $ - req_types - 1 
+    req_get db 'GET', 0     
+    req_get_length equ $ - req_get - 1 
 
     req_head db 'HEAD', 0     
     req_head_length equ $ - req_head - 1 
 
-    req_type_ptrs dq req_types, req_head ; array of request types
+    req_type_ptrs dq req_get, req_head ; array of request types
     req_type_lengths dq req_get_length, req_head_length 

--- a/data.asm
+++ b/data.asm
@@ -172,12 +172,7 @@
     http_dir_entry_open_a_tag_post db '">',0x00
     http_dir_entry_close_a_tag db '</a></p>',0x00
 
-    ; Request type
-    req_get db 'GET', 0     
-    req_get_offset equ $ - req_get
-
-    req_head db 'HEAD', 0     
-    req_head_offset equ $ - req_head
-
-    req_type_ptrs dq req_get, req_head ; array of request types
-    req_type_count equ ($ - req_type_ptrs) / 8
+    ; Request type  
+    request_types db "GET ", "HEAD " ; space after each request type
+    request_values db REQ_GET, REQ_HEAD
+    num_requests equ ($ - request_types) / 4

--- a/http.asm
+++ b/http.asm
@@ -410,34 +410,23 @@ get_request_type: ;rdi - pointer to buffer, ret = rax: request type
     mov rax, r10
     add rax, 0x03
     mov [request_offset], rax
-    xor rbx, rbx
-
-    mov rax, REQ_UNK
-
-  check_request:
-    ; add to array in data in order check to the request type
-    mov rsi, [req_type_ptrs + rbx * 8] 
-    mov rcx, -1
-    mov rdx, rdi
-
-    repe cmpsb              
-    jne next_request 
-
-    jmp [req_type_ptrs + rbx * 8] ; automatically jmp to the correct method
-
-  next_request:
-    inc rbx               
-    cmp rbx, req_type_count  
-    jne check_request 
-
-  set_req_get:
-    mov rax, REQ_GET
-    jmp request_type_return                  
-
-  set_req_head:
-    mov rax, REQ_HEAD
-    jmp request_type_return
     
-  request_type_return:
+    mov rax, REQ_UNK
+    
+    check_request_loop:
+    mov edx, [rdi]
+    lea rsi, [request_types + rbx * 4] 
+    cmp edx, [rsi]
+    jne next_request
+
+    movzx rax, byte [request_values + rbx]
+    jmp request_type_return
+
+    next_request:
+    inc rbx
+    cmp rbx, num_requests
+    jl check_request_loop
+
+    request_type_return:
     stackpop
     ret

--- a/http.asm
+++ b/http.asm
@@ -410,36 +410,34 @@ get_request_type: ;rdi - pointer to buffer, ret = rax: request type
     mov rax, r10
     add rax, 0x03
     mov [request_offset], rax
+    xor rbx, rbx
 
     mov rax, REQ_UNK
 
   check_request:
     ; add to array in data in order check to the request type
-
-    mov rsi, [req_type_ptrs + rbx * 8]  
-    mov rcx, [req_type_lengths + rbx * 8]
+    mov rsi, [req_type_ptrs + rbx * 8] 
+    mov rcx, -1
+    mov rdx, rdi
 
     repe cmpsb              
     jne next_request 
 
-    cmp rbx, 0              
-    je set_req_get
-    cmp rbx, 1             
-    je set_req_head
+    jmp [req_type_ptrs + rbx * 8] ; automatically jmp to the correct method
+
+  next_request:
+    inc rbx               
+    cmp rbx, req_type_count  
+    jne check_request 
 
   set_req_get:
     mov rax, REQ_GET
-    jmp request_type_return                      
+    jmp request_type_return                  
 
   set_req_head:
     mov rax, REQ_HEAD
     jmp request_type_return
-
-  next_request:
-    inc rbx                
-    cmp rbx, rdx   
-    jl check_request 
-
+    
   request_type_return:
     stackpop
     ret

--- a/http.asm
+++ b/http.asm
@@ -413,26 +413,33 @@ get_request_type: ;rdi - pointer to buffer, ret = rax: request type
 
     mov rax, REQ_UNK
 
-    check_get:
-    cmp byte[rdi+0], 0x47
-    jne check_head
-    cmp byte[rdi+1], 0x45
-    jne check_head
-    cmp byte[rdi+2], 0x54
-    jne check_head
+  check_request:
+    ; add to array in data in order check to the request type
+
+    mov rsi, [req_type_ptrs + rbx * 8]  
+    mov rcx, [req_type_lengths + rbx * 8]
+
+    repe cmpsb              
+    jne next_request 
+
+    cmp rbx, 0              
+    je set_req_get
+    cmp rbx, 1             
+    je set_req_head
+
+  set_req_get:
     mov rax, REQ_GET
+    jmp request_type_return                      
 
-    check_head:
-    cmp byte[rdi+0], 0x48
-    jne request_type_return
-    cmp byte[rdi+1], 0x45
-    jne request_type_return
-    cmp byte[rdi+2], 0x41
-    jne request_type_return
-    cmp byte[rdi+3], 0x44
-    jne request_type_return
+  set_req_head:
     mov rax, REQ_HEAD
+    jmp request_type_return
 
-    request_type_return:
+  next_request:
+    inc rbx                
+    cmp rbx, rdx   
+    jl check_request 
+
+  request_type_return:
     stackpop
     ret


### PR DESCRIPTION
# Added:
 pointer array for request types, this will make it more maintainable, if you want to add a request type then you can add it to the array in data.asm

# Changed:
the get_check and head_check method, this is now a loop that runs until one of the strings are matched in the above mentioned array

---

this is a pull request for the issue #37 ,  Byte-wise comparison of HEAD, GET, etc.