### PR TITLE
Bugfix for serving jpeg files & Add support for .txt files

### DIFF
--- a/constants.asm
+++ b/constants.asm
@@ -78,6 +78,7 @@
 %define CONTENT_TYPE_PNG          7
 %define CONTENT_TYPE_JPEG         8
 %define CONTENT_TYPE_SVG          9
+%define CONTENT_TYPE_TXT         10
 
 ;Dirent types
 %define DT_UNKNOWN 0

--- a/data.asm
+++ b/data.asm
@@ -149,6 +149,9 @@
     content_type_svg db "image/svg+xml",0x0d,0x0a,0x00
     content_type_svg_len equ $ - content_type_svg
 
+    content_type_txt db "text/plain",0x0d,0x0a,0x00
+    content_type_txt_len equ $ - content_type_txt
+
     default_document db "/index.html",0x00
     default_document_len equ $ - default_document
     
@@ -164,6 +167,7 @@
     extension_jpeg     db ".jpeg",0x00
     extension_png      db ".png",0x00
     extension_svg      db ".svg",0x00
+    extension_txt      db ".txt",0x00
 
     ; dir listing
     http_200_dir_list_open_h1_tag db "<h1>Index of ",0x00

--- a/http.asm
+++ b/http.asm
@@ -166,10 +166,12 @@ add_content_type_header: ;rdi - pointer to buffer, rsi - type
     add_response_jpeg:
     mov rsi, content_type_jpeg
     call string_concat
+    jmp add_response_cont
 
     add_response_svg:
     mov rsi, content_type_svg
     call string_concat
+    jmp add_response_cont
 
 
     add_response_cont:

--- a/http.asm
+++ b/http.asm
@@ -86,6 +86,12 @@ detect_content_type: ;rdi - pointer to buffer that contains request, ret - rax: 
     cmp rax, 1
     je detect_content_type_ret
 
+    mov rsi, extension_txt
+    call string_ends_with
+    mov r10, CONTENT_TYPE_TXT
+    cmp rax, 1
+    je detect_content_type_ret
+
     mov r10, CONTENT_TYPE_OCTET_STREAM ; default to octet-stream
     detect_content_type_ret:
     mov rax, r10
@@ -120,6 +126,8 @@ add_content_type_header: ;rdi - pointer to buffer, rsi - type
     je add_response_jpeg
     cmp r10, CONTENT_TYPE_SVG
     je add_response_svg
+    cmp r10, CONTENT_TYPE_TXT
+    je add_response_txt
     
     jmp add_response_octet_stream
 
@@ -170,6 +178,11 @@ add_content_type_header: ;rdi - pointer to buffer, rsi - type
 
     add_response_svg:
     mov rsi, content_type_svg
+    call string_concat
+    jmp add_response_cont
+
+    add_response_txt:
+    mov rsi, content_type_txt
     call string_concat
     jmp add_response_cont
 


### PR DESCRIPTION
I wanted to add support for plain text files (like robots.txt) and noticed this bug along the way